### PR TITLE
No-Op Implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,15 +17,25 @@ tasks {
     }
 }
 
+sourceSets {
+    noop {
+        java.srcDir 'src/noop/kotlin'
+    }
+}
+
 dependencies {
     implementation platform('org.jetbrains.kotlin:kotlin-bom')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
-    implementation 'org.slf4j:slf4j-api:1.7.28'
-    testImplementation 'org.slf4j:slf4j-simple:1.7.28'
+    implementation 'org.slf4j:slf4j-api:1.7.32'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.32'
+
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
+
+    noopImplementation 'org.slf4j:slf4j-nop:1.7.32'
+    noopImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 task dokkaJar(type: Jar) {
@@ -41,8 +51,28 @@ task sourcesJar(type: Jar) {
     from(sourceSets.getByName("main").allSource)
 }
 
+task noopSources(type: Jar) {
+    archiveClassifier.set("sources")
+    from(sourceSets.noop.allSource)
+}
+
+task noopBinary(type: Jar) {
+    archiveClassifier.set("")
+    from(sourceSets.noop.output)
+}
+
 publishing {
     publications {
+        noop(MavenPublication) {
+            artifact noopSources
+            artifact noopBinary
+
+            pom {
+                name = "ktee-noop"
+                artifactId = "ktee-noop"
+            }
+        }
+
         mavenJava(MavenPublication) {
             from components.java
             artifact sourcesJar
@@ -50,7 +80,8 @@ publishing {
 
             pom {
                 name = "ktee"
-                description = "KTee is Tee for Kotlin code pipelines. If you love the unix command line tee, you know what we mean."
+                description = "KTee is Tee for Kotlin code pipelines. " +
+                        "If you love the unix command line tee, you know what we mean."
                 url.set("https://github.com/medly/ktee")
                 licenses {
                     license {
@@ -103,4 +134,5 @@ signing {
     def signingPassword = System.getenv("OSSRH_SIGNING_PASSPHRASE")
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign publishing.publications.mavenJava
+    sign publishing.publications.noop
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
 }
 
 repositories {

--- a/src/main/kotlin/ktee/KTee.kt
+++ b/src/main/kotlin/ktee/KTee.kt
@@ -3,7 +3,23 @@ package ktee
 import ktee.KTee.Companion.debug
 import org.slf4j.Logger
 
-class KTee { companion object { var debug = true } }
+class KTee {
+    companion object {
+        var debugChanged = false
+            private set
+
+        /**
+         * If debug is set to false, all tee
+         * functions won't output anything.
+         *
+         * Variable can be set only once!
+         */
+        var debug = true
+            @Synchronized set(value) {
+                if(!debugChanged) { debugChanged = true; field = value }
+                else throw IllegalStateException("Variable debug has already been set once.")
+            }
+    } }
 
 /**
  * Prints the value to the stdout and returns the same value. Useful when chaining

--- a/src/main/kotlin/ktee/KTee.kt
+++ b/src/main/kotlin/ktee/KTee.kt
@@ -1,7 +1,9 @@
 package ktee
 
+import ktee.KTee.Companion.debug
 import org.slf4j.Logger
 
+class KTee { companion object { var debug = true } }
 
 /**
  * Prints the value to the stdout and returns the same value. Useful when chaining
@@ -13,7 +15,7 @@ import org.slf4j.Logger
  *
  */
 fun <T> T.tee(marker: String = ""): T {
-    println(marker + this)
+    if (debug) println(marker + this)
     return this
 }
 
@@ -23,7 +25,7 @@ fun <T> T.tee(marker: String = ""): T {
  *
  */
 inline fun <T> T.tee(fn: (T) -> String): T {
-    println(fn(this))
+    if (debug) println(fn(this))
     return this
 }
 
@@ -31,7 +33,7 @@ inline fun <T> T.tee(fn: (T) -> String): T {
  * logs the value to the given logger at info level. Message can be customized using message parameter
  */
 fun <T> T.teeToInfo(logger: Logger, message: String = "{}"): T {
-    logger.info(message, this)
+    if (debug) logger.info(message, this)
     return this
 }
 
@@ -40,7 +42,7 @@ fun <T> T.teeToInfo(logger: Logger, message: String = "{}"): T {
  *
  */
 inline fun <T> T.teeToInfo(logger: Logger, fn: (T) -> String): T {
-    logger.info(fn(this), this)
+    if (debug) logger.info(fn(this), this)
     return this
 }
 
@@ -48,7 +50,7 @@ inline fun <T> T.teeToInfo(logger: Logger, fn: (T) -> String): T {
  * logs the value to the given logger at info level. Message can be customized using message parameter
  */
 fun <T> T.teeToDebug(logger: Logger, message: String = "{}"): T {
-    logger.debug(message, this)
+    if (debug) logger.debug(message, this)
     return this
 }
 
@@ -57,7 +59,7 @@ fun <T> T.teeToDebug(logger: Logger, message: String = "{}"): T {
  *
  */
 inline fun <T> T.teeToDebug(logger: Logger, fn: (T) -> String): T {
-    logger.debug(fn(this), this)
+    if (debug) logger.debug(fn(this), this)
     return this
 }
 
@@ -65,7 +67,7 @@ inline fun <T> T.teeToDebug(logger: Logger, fn: (T) -> String): T {
  * logs the value to the given logger at trace level. Message can be customized using message parameter
  */
 fun <T> T.teeToTrace(logger: Logger, message: String = "{}"): T {
-    logger.trace(message, this)
+    if (debug) logger.trace(message, this)
     return this
 }
 
@@ -74,7 +76,7 @@ fun <T> T.teeToTrace(logger: Logger, message: String = "{}"): T {
  *
  */
 inline fun <T> T.teeToTrace(logger: Logger, fn: (T) -> String): T {
-    logger.trace(fn(this), this)
+    if (debug) logger.trace(fn(this), this)
     return this
 }
 

--- a/src/main/kotlin/ktee/KTee.kt
+++ b/src/main/kotlin/ktee/KTee.kt
@@ -1,25 +1,6 @@
 package ktee
 
-import ktee.KTee.Companion.debug
 import org.slf4j.Logger
-
-class KTee {
-    companion object {
-        var debugChanged = false
-            private set
-
-        /**
-         * If debug is set to false, all tee
-         * functions won't output anything.
-         *
-         * Variable can be set only once!
-         */
-        var debug = true
-            @Synchronized set(value) {
-                if(!debugChanged) { debugChanged = true; field = value }
-                else throw IllegalStateException("Variable debug has already been set once.")
-            }
-    } }
 
 /**
  * Prints the value to the stdout and returns the same value. Useful when chaining
@@ -30,53 +11,53 @@ class KTee {
  * myList.map(fn).tee(">>> ").reduce(fn)
  *
  */
-fun <T> T.tee(marker: String = "") = apply { if (debug) println(marker + this) }
+fun <T> T.tee(marker: String = "") = apply { println(marker + this) }
 
 /**
  *
  * executes the lambda with the value of the chain and writes the
  *
  */
-inline fun <T> T.tee(fn: (T) -> String) = apply { if (debug) println(fn(this)) }
+inline fun <T> T.tee(fn: (T) -> String) = apply { println(fn(this)) }
 
 /**
  * logs the value to the given logger at info level. Message can be customized using message parameter
  */
 fun <T> T.teeToInfo(logger: Logger, message: String = "{}")
-        = apply { if (debug) logger.info(message, this) }
+        = apply { logger.info(message, this) }
 
 /**
  * Evaluates the lambda and logs the result (of evaluation) to the given logger at info level
  *
  */
 inline fun <T> T.teeToInfo(logger: Logger, fn: (T) -> String)
-        = apply { if (debug) logger.info(fn(this), this) }
+        = apply { logger.info(fn(this), this) }
 
 /**
  * logs the value to the given logger at info level. Message can be customized using message parameter
  */
 fun <T> T.teeToDebug(logger: Logger, message: String = "{}")
-        = apply { if (debug) logger.debug(message, this) }
+        = apply { logger.debug(message, this) }
 
 /**
  * Evaluates the lambda and logs the result (of evaluation) to the given logger at debug level
  *
  */
 inline fun <T> T.teeToDebug(logger: Logger, fn: (T) -> String)
-        = apply { if (debug) logger.debug(fn(this), this) }
+        = apply { logger.debug(fn(this), this) }
 
 /**
  * logs the value to the given logger at trace level. Message can be customized using message parameter
  */
 fun <T> T.teeToTrace(logger: Logger, message: String = "{}")
-        = apply { if (debug) logger.trace(message, this) }
+        = apply { logger.trace(message, this) }
 
 /**
  * Evaluates the lambda and logs the result (of evaluation) to the given logger at trace level
  *
  */
 inline fun <T> T.teeToTrace(logger: Logger, fn: (T) -> String)
-        = apply { if (debug) logger.trace(fn(this), this) }
+        = apply { logger.trace(fn(this), this) }
 
 
 

--- a/src/main/kotlin/ktee/KTee.kt
+++ b/src/main/kotlin/ktee/KTee.kt
@@ -14,71 +14,53 @@ class KTee { companion object { var debug = true } }
  * myList.map(fn).tee(">>> ").reduce(fn)
  *
  */
-fun <T> T.tee(marker: String = ""): T {
-    if (debug) println(marker + this)
-    return this
-}
+fun <T> T.tee(marker: String = "") = apply { if (debug) println(marker + this) }
 
 /**
  *
  * executes the lambda with the value of the chain and writes the
  *
  */
-inline fun <T> T.tee(fn: (T) -> String): T {
-    if (debug) println(fn(this))
-    return this
-}
+inline fun <T> T.tee(fn: (T) -> String) = apply { if (debug) println(fn(this)) }
 
 /**
  * logs the value to the given logger at info level. Message can be customized using message parameter
  */
-fun <T> T.teeToInfo(logger: Logger, message: String = "{}"): T {
-    if (debug) logger.info(message, this)
-    return this
-}
+fun <T> T.teeToInfo(logger: Logger, message: String = "{}")
+        = apply { if (debug) logger.info(message, this) }
 
 /**
  * Evaluates the lambda and logs the result (of evaluation) to the given logger at info level
  *
  */
-inline fun <T> T.teeToInfo(logger: Logger, fn: (T) -> String): T {
-    if (debug) logger.info(fn(this), this)
-    return this
-}
+inline fun <T> T.teeToInfo(logger: Logger, fn: (T) -> String)
+        = apply { if (debug) logger.info(fn(this), this) }
 
 /**
  * logs the value to the given logger at info level. Message can be customized using message parameter
  */
-fun <T> T.teeToDebug(logger: Logger, message: String = "{}"): T {
-    if (debug) logger.debug(message, this)
-    return this
-}
+fun <T> T.teeToDebug(logger: Logger, message: String = "{}")
+        = apply { if (debug) logger.debug(message, this) }
 
 /**
  * Evaluates the lambda and logs the result (of evaluation) to the given logger at debug level
  *
  */
-inline fun <T> T.teeToDebug(logger: Logger, fn: (T) -> String): T {
-    if (debug) logger.debug(fn(this), this)
-    return this
-}
+inline fun <T> T.teeToDebug(logger: Logger, fn: (T) -> String)
+        = apply { if (debug) logger.debug(fn(this), this) }
 
 /**
  * logs the value to the given logger at trace level. Message can be customized using message parameter
  */
-fun <T> T.teeToTrace(logger: Logger, message: String = "{}"): T {
-    if (debug) logger.trace(message, this)
-    return this
-}
+fun <T> T.teeToTrace(logger: Logger, message: String = "{}")
+        = apply { if (debug) logger.trace(message, this) }
 
 /**
  * Evaluates the lambda and logs the result (of evaluation) to the given logger at trace level
  *
  */
-inline fun <T> T.teeToTrace(logger: Logger, fn: (T) -> String): T {
-    if (debug) logger.trace(fn(this), this)
-    return this
-}
+inline fun <T> T.teeToTrace(logger: Logger, fn: (T) -> String)
+        = apply { if (debug) logger.trace(fn(this), this) }
 
 
 

--- a/src/noop/kotlin/ktee/KTee.kt
+++ b/src/noop/kotlin/ktee/KTee.kt
@@ -1,0 +1,16 @@
+package ktee
+
+import org.slf4j.Logger
+
+inline fun <T> T.tee(fn: (T) -> String) = this
+inline fun <T> T.tee(marker: String = "") = this
+inline fun <T> T.teeToInfo(logger: Logger, fn: (T) -> String) = this
+inline fun <T> T.teeToDebug(logger: Logger, fn: (T) -> String) = this
+inline fun <T> T.teeToTrace(logger: Logger, fn: (T) -> String) = this
+inline fun <T> T.teeToInfo(logger: Logger, message: String = "{}") = this
+inline fun <T> T.teeToDebug(logger: Logger, message: String = "{}") = this
+inline fun <T> T.teeToTrace(logger: Logger, message: String = "{}") = this
+
+
+
+

--- a/src/test/kotlin/ktee/KTeeTest.kt
+++ b/src/test/kotlin/ktee/KTeeTest.kt
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class KTeeTest {
@@ -64,4 +65,60 @@ class KTeeTest {
         outputs.forEach { assertTrue { it.endsWith("hello myval\n") } }
     }
 
+    @Test
+    fun `should throw IllegalStateException`() {
+        assertFailsWith<IllegalStateException> {
+            KTee.debug = false; KTee.debug = false }
+    }
+
+    @Test
+    fun `should not write to stdout`() {
+        if (!KTee.debugChanged) KTee.debug = false
+        assertEquals("", trapOut { "myval".tee() })
+    }
+
+    @Test
+    fun `should evaluate lambda and not write to stdout`() {
+        if (!KTee.debugChanged) KTee.debug = false
+        assertEquals("", trapOut { "myval".tee { v -> "value is $v" } })
+    }
+
+    @Test
+    fun `should not write to logger`() {
+        if (!KTee.debugChanged) KTee.debug = false
+        assertTrue(trapErr { "myval".teeToInfo(logger) } == "")
+    }
+
+    @Test
+    fun `should not log with info level`() {
+        if (!KTee.debugChanged) KTee.debug = false
+        val outputs = listOf(
+                trapErr { "myval".teeToInfo(logger, "hello {}") },
+                trapErr { "myval".teeToInfo(logger) { "hello $it" } },
+                trapErr { "myval".teeToInfo(logger) { "hello {}" } }
+        )
+        outputs.forEach { assertTrue { !it.contains("INFO") } }
+    }
+
+    @Test
+    fun `should not log with trace level`() {
+        if (!KTee.debugChanged) KTee.debug = false
+        val outputs = listOf(
+                trapErr { "myval".teeToTrace(logger, "hello {}") },
+                trapErr { "myval".teeToTrace(logger) { "hello $it" } },
+                trapErr { "myval".teeToTrace(logger) { "hello {}" } }
+        )
+        outputs.forEach { assertTrue { it == "" } }
+    }
+
+    @Test
+    fun `should not log with debug level`() {
+        if (!KTee.debugChanged) KTee.debug = false
+        val outputs = listOf(
+                trapErr { "myval".teeToDebug(logger, "hello {}") },
+                trapErr { "myval".teeToDebug(logger) { "hello $it" } },
+                trapErr { "myval".teeToDebug(logger) { "hello {}" } }
+        )
+        outputs.forEach { assertTrue { !it.contains("DEBUG") } }
+    }
 }

--- a/src/test/kotlin/ktee/KTeeTest.kt
+++ b/src/test/kotlin/ktee/KTeeTest.kt
@@ -19,17 +19,17 @@ class KTeeTest {
 
     @Test
     fun `should write to stdout`() {
-        assertEquals("myval\n", trapOut { "myval".tee() })
+        assertEquals("myval" + System.lineSeparator(), trapOut { "myval".tee() })
     }
 
     @Test
     fun `should evaluate lambda and write to stdout`() {
-        assertEquals("value is myval\n", trapOut { "myval".tee { v -> "value is $v" } })
+        assertEquals("value is myval" + System.lineSeparator(), trapOut { "myval".tee { v -> "value is $v" } })
     }
 
     @Test
     fun `should write to logger`() {
-        assertTrue(trapErr { "myval".teeToInfo(logger) }.endsWith("myval\n"))
+        assertTrue(trapErr { "myval".teeToInfo(logger) }.endsWith("myval" + System.lineSeparator()))
     }
 
     @Test
@@ -40,18 +40,18 @@ class KTeeTest {
                 trapErr { "myval".teeToInfo(logger) { "hello {}" } }
         )
         outputs.forEach { assertTrue { it.contains("INFO") } }
-        outputs.forEach { assertTrue { it.endsWith("hello myval\n") } }
+        outputs.forEach { assertTrue { it.endsWith("hello myval" + System.lineSeparator()) } }
     }
 
     @Test
-    fun `should log with trace() level`() {
+    fun `should log with trace level`() {
         val outputs = listOf(
                 trapErr { "myval".teeToTrace(logger, "hello {}") },
                 trapErr { "myval".teeToTrace(logger) { "hello $it" } },
                 trapErr { "myval".teeToTrace(logger) { "hello {}" } }
         )
         outputs.forEach { assertTrue { it.contains("TRACE") } }
-        outputs.forEach { assertTrue { it.endsWith("hello myval\n") } }
+        outputs.forEach { assertTrue { it.endsWith("hello myval" + System.lineSeparator()) } }
     }
 
     @Test
@@ -62,7 +62,7 @@ class KTeeTest {
                 trapErr { "myval".teeToDebug(logger) { "hello {}" } }
         )
         outputs.forEach { assertTrue { it.contains("DEBUG") } }
-        outputs.forEach { assertTrue { it.endsWith("hello myval\n") } }
+        outputs.forEach { assertTrue { it.endsWith("hello myval" + System.lineSeparator()) } }
     }
 
     @Test

--- a/src/test/kotlin/ktee/KTeeTest.kt
+++ b/src/test/kotlin/ktee/KTeeTest.kt
@@ -4,7 +4,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class KTeeTest {
@@ -65,60 +64,4 @@ class KTeeTest {
         outputs.forEach { assertTrue { it.endsWith("hello myval" + System.lineSeparator()) } }
     }
 
-    @Test
-    fun `should throw IllegalStateException`() {
-        assertFailsWith<IllegalStateException> {
-            KTee.debug = false; KTee.debug = false }
-    }
-
-    @Test
-    fun `should not write to stdout`() {
-        if (!KTee.debugChanged) KTee.debug = false
-        assertEquals("", trapOut { "myval".tee() })
-    }
-
-    @Test
-    fun `should not evaluate lambda or write to stdout`() {
-        if (!KTee.debugChanged) KTee.debug = false
-        assertEquals("", trapOut { "myval".tee { v -> "value is $v" } })
-    }
-
-    @Test
-    fun `should not write to logger`() {
-        if (!KTee.debugChanged) KTee.debug = false
-        assertTrue(trapErr { "myval".teeToInfo(logger) } == "")
-    }
-
-    @Test
-    fun `should not log with info level`() {
-        if (!KTee.debugChanged) KTee.debug = false
-        val outputs = listOf(
-                trapErr { "myval".teeToInfo(logger, "hello {}") },
-                trapErr { "myval".teeToInfo(logger) { "hello $it" } },
-                trapErr { "myval".teeToInfo(logger) { "hello {}" } }
-        )
-        outputs.forEach { assertTrue { !it.contains("INFO") } }
-    }
-
-    @Test
-    fun `should not log with trace level`() {
-        if (!KTee.debugChanged) KTee.debug = false
-        val outputs = listOf(
-                trapErr { "myval".teeToTrace(logger, "hello {}") },
-                trapErr { "myval".teeToTrace(logger) { "hello $it" } },
-                trapErr { "myval".teeToTrace(logger) { "hello {}" } }
-        )
-        outputs.forEach { assertTrue { it == "" } }
-    }
-
-    @Test
-    fun `should not log with debug level`() {
-        if (!KTee.debugChanged) KTee.debug = false
-        val outputs = listOf(
-                trapErr { "myval".teeToDebug(logger, "hello {}") },
-                trapErr { "myval".teeToDebug(logger) { "hello $it" } },
-                trapErr { "myval".teeToDebug(logger) { "hello {}" } }
-        )
-        outputs.forEach { assertTrue { !it.contains("DEBUG") } }
-    }
 }

--- a/src/test/kotlin/ktee/KTeeTest.kt
+++ b/src/test/kotlin/ktee/KTeeTest.kt
@@ -78,7 +78,7 @@ class KTeeTest {
     }
 
     @Test
-    fun `should evaluate lambda and not write to stdout`() {
+    fun `should not evaluate lambda or write to stdout`() {
         if (!KTee.debugChanged) KTee.debug = false
         assertEquals("", trapOut { "myval".tee { v -> "value is $v" } })
     }


### PR DESCRIPTION
###### Edit:
With this PR, two artifacts will be published, `ktee` and `ktee-noop`.
As the name suggests, `ktee-noop` has no internal functionality and it can be used in production environment with no overhead.

>~~With this PR, the user can enable or disable logging and printing by setting `KTee.debug` variable true or false.~~
>
>~~This can be automated depending your build, for example in Android the user can set the variable as `KTee.debug = BuildConfig.DEBUG` at the start of his app.~~
>
>~~By default is set to true.~~

PS. I think this was suggested by someone in Reddit.